### PR TITLE
OS-specific command for rmdir and xcopy

### DIFF
--- a/iwd2ee/iwd2ee.tp2
+++ b/iwd2ee/iwd2ee.tp2
@@ -59,8 +59,17 @@ ALWAYS
 			UNINSTALL ~ddrawfix.tp2~ ~2~
 //			ACTION_IF input = 1 BEGIN
 				COPY ~%mod_folder%/ddrawfix~ ~./~
-				AT_NOW ~rmdir "Shaders" /s /q & xcopy "%mod_folder%\ddrawfix\Shaders" "Shaders" /i /s /e~ EXACT
-				AT_UNINSTALL ~rmdir "Shaders" /s /q~ EXACT
+				ACTION_MATCH ~%WEIDU_OS%~ WITH
+				  win32
+				  BEGIN
+				    AT_NOW ~rmdir "Shaders" /s /q & xcopy "%mod_folder%\ddrawfix\Shaders" "Shaders" /i /s /e~ EXACT
+				    AT_UNINSTALL ~rmdir "Shaders" /s /q~ EXACT
+				  END
+				  DEFAULT
+				    // This supposes osx works as unix but I actually don't know
+				    AT_NOW ~rm -Rf Shaders && cp -r "%mod_folder%/ddrawfix/Shaders" .~ EXACT
+				    AT_UNINSTALL ~rm -Rf Shaders~ EXACT
+				END
 //			END ELSE ACTION_IF input = 2 BEGIN
 //				INCLUDE ~%mod_folder%/components/ddrawfix2.tpa~
 //			END


### PR DESCRIPTION
Check the value of WEIDU_OS when setting-up the <game_dir>/Shaders directory.
- rmdir/windows and rmdir/unix have very different command line options and behaviour.
- xcopy doesn't exist at least on linux (couldn't check on osx)

No idea if this is in acceptable condition for a merge, maybe it's more of the "how it could be done" kind.

Tested on linux but not on either windows or osx. The game loads but I had to start Config.exe before and explicitely select 32 bit color radio button, else IWD2EE.exe shows a dialog that says something like "couldn' find 16 color mode" and the game freezes (but plays music).